### PR TITLE
Add Helm chart and Argo CD app for Kubernetes deployment

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -1,0 +1,17 @@
+# Argo CD application manifest
+
+The `applications/springcloud-msa.yaml` manifest defines an Argo CD `Application` that deploys the Helm chart in this repository.
+
+Apply it in a cluster where Argo CD is installed:
+
+```bash
+kubectl apply -f argocd/applications/springcloud-msa.yaml
+```
+
+The manifest instructs Argo CD to:
+
+- Track this Git repository (`path: helm/springcloud-msa`).
+- Deploy the chart into the `springcloud-msa` namespace.
+- Automatically create the namespace and keep the deployment in sync (self-heal + prune).
+
+Update the `repoURL` or `targetRevision` fields if you push the chart to a fork or tag.

--- a/argocd/applications/springcloud-msa.yaml
+++ b/argocd/applications/springcloud-msa.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: springcloud-msa
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/maosella/springcloudMSA
+    targetRevision: HEAD
+    path: helm/springcloud-msa
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: springcloud-msa
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/helm/springcloud-msa/Chart.yaml
+++ b/helm/springcloud-msa/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: springcloud-msa
+version: 0.1.0
+description: Helm chart for deploying the Spring Cloud microservices architecture
+kubeVersion: ">=1.21.0"
+type: application
+appVersion: "1.0.0"

--- a/helm/springcloud-msa/README.md
+++ b/helm/springcloud-msa/README.md
@@ -1,0 +1,40 @@
+# Spring Cloud MSA Helm chart
+
+This chart packages the services that compose the Spring Cloud microservices architecture used in the CTD final project. It creates Deployments/StatefulSets and Services for:
+
+- Eureka discovery server
+- Centralized Spring Cloud Config server
+- API Gateway
+- Catalog, Movie and Series microservices
+- Supporting infrastructure: MySQL, MongoDB (+ Mongo Express), RabbitMQ and Zipkin
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Persistent volume provisioner in the cluster (for MySQL and MongoDB)
+- Container images for the microservices available in a registry reachable from the cluster (the default image names match those produced by the existing Dockerfiles)
+
+## Installing the chart
+
+```bash
+helm upgrade --install springcloud-msa ./helm/springcloud-msa \
+  --namespace springcloud-msa --create-namespace
+```
+
+Override values as needed, e.g. to point to a custom container registry or to change resource requests:
+
+```bash
+helm upgrade --install springcloud-msa ./helm/springcloud-msa \
+  --namespace springcloud-msa --create-namespace \
+  --set movieService.image.repository=my-registry/movie-service \
+  --set mysql.persistence.storageClassName=gp3
+```
+
+## Configuration highlights
+
+- `configServer.env.gitUri` and `gitSearchPaths` control the Git repository consumed by the config service.
+- `mysql.*` and `mongodb.*` sections define credentials and persistence options for the backing databases used by the microservices.
+- Each microservice exposes `javaOpts`, `resources`, and Kubernetes scheduling knobs (`nodeSelector`, `tolerations`, `affinity`).
+- The API Gateway service type defaults to `LoadBalancer` to expose the entry point outside the cluster; change it to `ClusterIP` if an ingress controller is preferred.
+
+Refer to `values.yaml` for the complete list of tunable parameters.

--- a/helm/springcloud-msa/templates/_helpers.tpl
+++ b/helm/springcloud-msa/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "springcloud-msa.labels" -}}
+app.kubernetes.io/name: {{ include "springcloud-msa.name" . }}
+helm.sh/chart: {{ include "springcloud-msa.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "springcloud-msa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "springcloud-msa.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "springcloud-msa.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "springcloud-msa.name" -}}
+{{ .Chart.Name }}
+{{- end }}
+
+{{- define "springcloud-msa.standardLabels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/springcloud-msa/templates/catalog-deployment.yaml
+++ b/helm/springcloud-msa/templates/catalog-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-service
+  labels:
+    app: catalog-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.catalogService.replicaCount }}
+  selector:
+    matchLabels:
+      app: catalog-service
+  template:
+    metadata:
+      labels:
+        app: catalog-service
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: catalog-service
+          image: "{{ .Values.catalogService.image.repository }}:{{ .Values.catalogService.image.tag }}"
+          imagePullPolicy: {{ .Values.catalogService.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.catalogService.service.port }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.catalogService.javaOpts | quote }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.catalogService.resources | indent 12 }}
+      {{- if .Values.catalogService.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.catalogService.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.catalogService.affinity }}
+      affinity:
+{{ toYaml .Values.catalogService.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.catalogService.tolerations }}
+      tolerations:
+{{ toYaml .Values.catalogService.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.catalogService.service.name }}
+  labels:
+    app: catalog-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.catalogService.service.type }}
+  selector:
+    app: catalog-service
+  ports:
+    - port: {{ .Values.catalogService.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/config-deployment.yaml
+++ b/helm/springcloud-msa/templates/config-deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-service
+  labels:
+    app: config-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.configServer.replicaCount }}
+  selector:
+    matchLabels:
+      app: config-service
+  template:
+    metadata:
+      labels:
+        app: config-service
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: config-service
+          image: "{{ .Values.configServer.image.repository }}:{{ .Values.configServer.image.tag }}"
+          imagePullPolicy: {{ .Values.configServer.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.configServer.service.port }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.configServer.javaOpts | quote }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+            - name: SPRING_CLOUD_CONFIG_SERVER_GIT_URI
+              value: {{ .Values.configServer.env.gitUri | quote }}
+            - name: SPRING_CLOUD_CONFIG_SERVER_GIT_SEARCH_PATHS
+              value: {{ .Values.configServer.env.gitSearchPaths | quote }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.configServer.resources | indent 12 }}
+      {{- if .Values.configServer.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.configServer.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.configServer.affinity }}
+      affinity:
+{{ toYaml .Values.configServer.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.configServer.tolerations }}
+      tolerations:
+{{ toYaml .Values.configServer.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.configServer.service.name }}
+  labels:
+    app: config-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.configServer.service.type }}
+  selector:
+    app: config-service
+  ports:
+    - port: {{ .Values.configServer.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/eureka-deployment.yaml
+++ b/helm/springcloud-msa/templates/eureka-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eureka-service
+  labels:
+    app: eureka-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.eureka.replicaCount }}
+  selector:
+    matchLabels:
+      app: eureka-service
+  template:
+    metadata:
+      labels:
+        app: eureka-service
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: eureka-service
+          image: "{{ .Values.eureka.image.repository }}:{{ .Values.eureka.image.tag }}"
+          imagePullPolicy: {{ .Values.eureka.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.eureka.service.port }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.eureka.javaOpts | quote }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.eureka.resources | indent 12 }}
+      {{- if .Values.eureka.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.eureka.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.eureka.affinity }}
+      affinity:
+{{ toYaml .Values.eureka.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.eureka.tolerations }}
+      tolerations:
+{{ toYaml .Values.eureka.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.eureka.service.name }}
+  labels:
+    app: eureka-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.eureka.service.type }}
+  selector:
+    app: eureka-service
+  ports:
+    - port: {{ .Values.eureka.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/gateway-deployment.yaml
+++ b/helm/springcloud-msa/templates/gateway-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.apiGateway.replicaCount }}
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: api-gateway
+          image: "{{ .Values.apiGateway.image.repository }}:{{ .Values.apiGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.apiGateway.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.apiGateway.service.targetPort }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.apiGateway.javaOpts | quote }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.apiGateway.resources | indent 12 }}
+      {{- if .Values.apiGateway.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.apiGateway.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.apiGateway.affinity }}
+      affinity:
+{{ toYaml .Values.apiGateway.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.apiGateway.tolerations }}
+      tolerations:
+{{ toYaml .Values.apiGateway.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.apiGateway.service.name }}
+  labels:
+    app: api-gateway
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.apiGateway.service.type }}
+  selector:
+    app: api-gateway
+  ports:
+    - port: {{ .Values.apiGateway.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/mongo-express-deployment.yaml
+++ b/helm/springcloud-msa/templates/mongo-express-deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.mongoExpress.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo-express
+  labels:
+    app: mongo-express
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.mongoExpress.replicaCount }}
+  selector:
+    matchLabels:
+      app: mongo-express
+  template:
+    metadata:
+      labels:
+        app: mongo-express
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: mongo-express
+          image: "{{ .Values.mongoExpress.image.repository }}:{{ .Values.mongoExpress.image.tag }}"
+          imagePullPolicy: {{ .Values.mongoExpress.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mongoExpress.service.port }}
+          env:
+            - name: ME_CONFIG_MONGODB_SERVER
+              value: {{ .Values.mongodb.service.name | quote }}
+            {{- if .Values.mongodb.auth.enabled }}
+            - name: ME_CONFIG_MONGODB_ADMINUSERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-auth
+                  key: username
+            - name: ME_CONFIG_MONGODB_ADMINPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-auth
+                  key: password
+            {{- end }}
+          resources:
+{{ toYaml .Values.mongoExpress.resources | indent 12 }}
+      {{- if .Values.mongoExpress.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.mongoExpress.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.mongoExpress.affinity }}
+      affinity:
+{{ toYaml .Values.mongoExpress.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.mongoExpress.tolerations }}
+      tolerations:
+{{ toYaml .Values.mongoExpress.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.mongoExpress.service.name }}
+  labels:
+    app: mongo-express
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mongoExpress.service.type }}
+  selector:
+    app: mongo-express
+  ports:
+    - port: {{ .Values.mongoExpress.service.port }}
+      targetPort: http
+      name: http
+{{- end }}

--- a/helm/springcloud-msa/templates/mongodb-statefulset.yaml
+++ b/helm/springcloud-msa/templates/mongodb-statefulset.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.mongodb.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-auth
+  labels:
+    app: mongodb
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: {{ .Values.mongodb.auth.rootUsername | quote }}
+  password: {{ .Values.mongodb.auth.rootPassword | quote }}
+  database: {{ .Values.mongodb.auth.database | quote }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.mongodb.service.name }}
+  replicas: {{ .Values.mongodb.replicaCount }}
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      labels:
+        app: mongodb
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mongodb.service.port }}
+              name: mongo
+          env:
+            {{- if .Values.mongodb.auth.enabled }}
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-auth
+                  key: username
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-auth
+                  key: password
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-auth
+                  key: database
+            {{- end }}
+          volumeMounts:
+            - name: mongodb-data
+              mountPath: /data/db
+          resources:
+{{ toYaml .Values.mongodb.resources | indent 12 }}
+      {{- if .Values.mongodb.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.mongodb.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.mongodb.affinity }}
+      affinity:
+{{ toYaml .Values.mongodb.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.mongodb.tolerations }}
+      tolerations:
+{{ toYaml .Values.mongodb.tolerations | indent 8 }}
+      {{- end }}
+{{- if .Values.mongodb.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mongodb-data
+        labels:
+          app: mongodb
+      spec:
+        accessModes:
+{{ toYaml .Values.mongodb.persistence.accessModes | indent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.mongodb.persistence.size }}
+        {{- if .Values.mongodb.persistence.storageClassName }}
+        storageClassName: {{ .Values.mongodb.persistence.storageClassName }}
+        {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.mongodb.service.name }}
+  labels:
+    app: mongodb
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    app: mongodb
+  ports:
+    - port: {{ .Values.mongodb.service.port }}
+      targetPort: mongo
+      name: mongo

--- a/helm/springcloud-msa/templates/movie-deployment.yaml
+++ b/helm/springcloud-msa/templates/movie-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: movie-service
+  labels:
+    app: movie-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.movieService.replicaCount }}
+  selector:
+    matchLabels:
+      app: movie-service
+  template:
+    metadata:
+      labels:
+        app: movie-service
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: movie-service
+          image: "{{ .Values.movieService.image.repository }}:{{ .Values.movieService.image.tag }}"
+          imagePullPolicy: {{ .Values.movieService.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.movieService.service.port }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.movieService.javaOpts | quote }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.movieService.resources | indent 12 }}
+      {{- if .Values.movieService.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.movieService.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.movieService.affinity }}
+      affinity:
+{{ toYaml .Values.movieService.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.movieService.tolerations }}
+      tolerations:
+{{ toYaml .Values.movieService.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.movieService.service.name }}
+  labels:
+    app: movie-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.movieService.service.type }}
+  selector:
+    app: movie-service
+  ports:
+    - port: {{ .Values.movieService.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/mysql-statefulset.yaml
+++ b/helm/springcloud-msa/templates/mysql-statefulset.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-auth
+  labels:
+    app: mysql
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  root-password: {{ .Values.mysql.auth.rootPassword | quote }}
+  username: {{ .Values.mysql.auth.username | quote }}
+  password: {{ .Values.mysql.auth.password | quote }}
+  database: {{ .Values.mysql.auth.database | quote }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.mysql.service.name }}
+  replicas: {{ .Values.mysql.replicaCount }}
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: mysql
+          image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.mysql.service.port }}
+              name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-auth
+                  key: root-password
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-auth
+                  key: database
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-auth
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-auth
+                  key: password
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          resources:
+{{ toYaml .Values.mysql.resources | indent 12 }}
+      {{- if .Values.mysql.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.mysql.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.mysql.affinity }}
+      affinity:
+{{ toYaml .Values.mysql.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.mysql.tolerations }}
+      tolerations:
+{{ toYaml .Values.mysql.tolerations | indent 8 }}
+      {{- end }}
+{{- if .Values.mysql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-data
+        labels:
+          app: mysql
+      spec:
+        accessModes:
+{{ toYaml .Values.mysql.persistence.accessModes | indent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.mysql.persistence.size }}
+        {{- if .Values.mysql.persistence.storageClassName }}
+        storageClassName: {{ .Values.mysql.persistence.storageClassName }}
+        {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.mysql.service.name }}
+  labels:
+    app: mysql
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    app: mysql
+  ports:
+    - port: {{ .Values.mysql.service.port }}
+      targetPort: mysql
+      name: mysql

--- a/helm/springcloud-msa/templates/namespace.yaml
+++ b/helm/springcloud-msa/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name | default .Release.Namespace }}
+  labels:
+    {{- include "springcloud-msa.standardLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/springcloud-msa/templates/rabbitmq-deployment.yaml
+++ b/helm/springcloud-msa/templates/rabbitmq-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.rabbitmq.replicaCount }}
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: rabbitmq
+          image: "{{ .Values.rabbitmq.image.repository }}:{{ .Values.rabbitmq.image.tag }}"
+          imagePullPolicy: {{ .Values.rabbitmq.image.pullPolicy }}
+          ports:
+            - name: amqp
+              containerPort: {{ .Values.rabbitmq.service.ports.amqp }}
+            - name: management
+              containerPort: {{ .Values.rabbitmq.service.ports.management }}
+          resources:
+{{ toYaml .Values.rabbitmq.resources | indent 12 }}
+      {{- if .Values.rabbitmq.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.rabbitmq.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.rabbitmq.affinity }}
+      affinity:
+{{ toYaml .Values.rabbitmq.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.rabbitmq.tolerations }}
+      tolerations:
+{{ toYaml .Values.rabbitmq.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.rabbitmq.service.name }}
+  labels:
+    app: rabbitmq
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.rabbitmq.service.type }}
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: {{ .Values.rabbitmq.service.ports.amqp }}
+      targetPort: amqp
+    - name: management
+      port: {{ .Values.rabbitmq.service.ports.management }}
+      targetPort: management

--- a/helm/springcloud-msa/templates/series-deployment.yaml
+++ b/helm/springcloud-msa/templates/series-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: series-service
+  labels:
+    app: series-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.seriesService.replicaCount }}
+  selector:
+    matchLabels:
+      app: series-service
+  template:
+    metadata:
+      labels:
+        app: series-service
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: series-service
+          image: "{{ .Values.seriesService.image.repository }}:{{ .Values.seriesService.image.tag }}"
+          imagePullPolicy: {{ .Values.seriesService.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.seriesService.service.port }}
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.seriesService.javaOpts | quote }}
+            - name: SPRING_PROFILES_ACTIVE
+              value: dev
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          resources:
+{{ toYaml .Values.seriesService.resources | indent 12 }}
+      {{- if .Values.seriesService.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.seriesService.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.seriesService.affinity }}
+      affinity:
+{{ toYaml .Values.seriesService.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.seriesService.tolerations }}
+      tolerations:
+{{ toYaml .Values.seriesService.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.seriesService.service.name }}
+  labels:
+    app: series-service
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.seriesService.service.type }}
+  selector:
+    app: series-service
+  ports:
+    - port: {{ .Values.seriesService.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/templates/zipkin-deployment.yaml
+++ b/helm/springcloud-msa/templates/zipkin-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zipkin
+  labels:
+    app: zipkin
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.zipkin.replicaCount }}
+  selector:
+    matchLabels:
+      app: zipkin
+  template:
+    metadata:
+      labels:
+        app: zipkin
+        {{- include "springcloud-msa.standardLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      containers:
+        - name: zipkin
+          image: "{{ .Values.zipkin.image.repository }}:{{ .Values.zipkin.image.tag }}"
+          imagePullPolicy: {{ .Values.zipkin.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.zipkin.service.port }}
+          resources:
+{{ toYaml .Values.zipkin.resources | indent 12 }}
+      {{- if .Values.zipkin.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.zipkin.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.zipkin.affinity }}
+      affinity:
+{{ toYaml .Values.zipkin.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.zipkin.tolerations }}
+      tolerations:
+{{ toYaml .Values.zipkin.tolerations | indent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.zipkin.service.name }}
+  labels:
+    app: zipkin
+    {{- include "springcloud-msa.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.zipkin.service.type }}
+  selector:
+    app: zipkin
+  ports:
+    - port: {{ .Values.zipkin.service.port }}
+      targetPort: http
+      name: http

--- a/helm/springcloud-msa/values.yaml
+++ b/helm/springcloud-msa/values.yaml
@@ -1,0 +1,206 @@
+global:
+  imagePullSecrets: []
+
+namespace:
+  create: false
+  name: springcloud-msa
+
+eureka:
+  replicaCount: 1
+  image:
+    repository: eureka-server
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: eureka-service
+    type: ClusterIP
+    port: 8761
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+configServer:
+  replicaCount: 1
+  image:
+    repository: config-service
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: config-service
+    type: ClusterIP
+    port: 8888
+  env:
+    gitUri: https://github.com/maosella/springcloudMSA
+    gitSearchPaths: microservices-config
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+movieService:
+  replicaCount: 1
+  image:
+    repository: movie-service
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: movie-service
+    type: ClusterIP
+    port: 8082
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+catalogService:
+  replicaCount: 1
+  image:
+    repository: catalog-service
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: catalog-service
+    type: ClusterIP
+    port: 8084
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+seriesService:
+  replicaCount: 1
+  image:
+    repository: series-service
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: series-service
+    type: ClusterIP
+    port: 8086
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+apiGateway:
+  replicaCount: 1
+  image:
+    repository: api-gateway
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: api-gateway
+    type: LoadBalancer
+    port: 80
+    targetPort: 8080
+  javaOpts: "-Xms256m -Xmx512m"
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+rabbitmq:
+  replicaCount: 1
+  image:
+    repository: rabbitmq
+    tag: 3.7.2-management
+    pullPolicy: IfNotPresent
+  service:
+    name: rabbitmq
+    type: ClusterIP
+    ports:
+      amqp: 5672
+      management: 15672
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+zipkin:
+  replicaCount: 1
+  image:
+    repository: openzipkin/zipkin
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: zipkin
+    type: ClusterIP
+    port: 9411
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+mongodb:
+  replicaCount: 1
+  image:
+    repository: mongo
+    tag: 5.0
+    pullPolicy: IfNotPresent
+  service:
+    name: mongodb
+    type: ClusterIP
+    port: 27017
+  auth:
+    enabled: true
+    rootUsername: rootuser
+    rootPassword: rootpass
+    database: tp_final
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    storageClassName: gp2
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+mongoExpress:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: mongo-express
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    name: mongo-express
+    type: ClusterIP
+    port: 8081
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+mysql:
+  replicaCount: 1
+  image:
+    repository: mysql
+    tag: 8.0
+    pullPolicy: IfNotPresent
+  service:
+    name: mysql
+    type: ClusterIP
+    port: 3306
+  auth:
+    rootPassword: rootpass
+    username: user
+    password: pass
+    database: tp_final
+  persistence:
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    storageClassName: gp2
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
## Summary
- add a Helm chart that templates the Spring Cloud services, backing databases and messaging dependencies
- document chart installation and configuration options
- provide an Argo CD Application manifest that tracks the chart and deploys it into the springcloud-msa namespace

## Testing
- python - <<'PY' ... (fails: ModuleNotFoundError: No module named 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_68cad4dcd86c832aa54bd56ebdcecd36